### PR TITLE
fix: modal-dialog backdrop

### DIFF
--- a/src/package/components/dialogs/modal-dialog.scss
+++ b/src/package/components/dialogs/modal-dialog.scss
@@ -3,6 +3,17 @@
     --width: min-content;
 }
 
+@starting-style {
+    .control[open] {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+
+    .control[open]::backdrop {
+        background-color: rgb(0 0 0 / 0%);
+    }
+}
+
 .control {
     $min-size: 100px;
     $easing: cubic-bezier(0.190, 1.000, 0.220, 1.000);
@@ -77,16 +88,5 @@
         &:active {
             background-color: rgba(0, 0, 0, 0.15);
         }
-    }
-}
-
-@starting-style {
-    .control[open] {
-        opacity: 0;
-        transform: scale(0.8);
-    }
-
-    .control[open]::backdrop {
-        background-color: rgb(0 0 0 / 0%);
     }
 }


### PR DESCRIPTION
+ Fixed an issue where the ::backdrop of `modal-dialog`'s dialog is transparent.