### PR TITLE
fix: progress spinner values

### DIFF
--- a/src/demo/public/modal-dialog.html
+++ b/src/demo/public/modal-dialog.html
@@ -21,6 +21,6 @@
     <button id="show-error">Show Error</button>
     <status-strip></status-strip>
 
-    <progress-spinner size="16"></progress-spinner>
+    <progress-spinner></progress-spinner>
 </body>
 </html>

--- a/src/package/components/progress/progress-spinner.d.ts
+++ b/src/package/components/progress/progress-spinner.d.ts
@@ -6,7 +6,9 @@ export declare class ProgressSpinner extends LitElement {
     private _r;
     size: number;
     color: string;
+    constructor();
     render(): import("lit").TemplateResult<1>;
+    protected firstUpdated(): void;
     protected updated(changes: Map<string, any>): void;
-    private setSize;
+    private updateSize;
 }

--- a/src/package/components/progress/progress-spinner.scss
+++ b/src/package/components/progress/progress-spinner.scss
@@ -1,6 +1,9 @@
 :host {
     --color: var(--accent-color);
+
     display: block;
+    height: 24px;
+    width: 24px;
 }
 
 .control {

--- a/src/package/components/progress/progress-spinner.ts
+++ b/src/package/components/progress/progress-spinner.ts
@@ -22,6 +22,13 @@ export class ProgressSpinner extends LitElement {
     @property()
     public color: string
 
+    constructor() {
+        super()
+        
+        // Will populate values for default 24px spinner...
+        this.updateSize()
+    }
+
     public render() {
         return html`
             <svg


### PR DESCRIPTION
+ Fixed an issue where the default values of the `_c` and `_r` properties of `progress-spinner` is empty and invalid.